### PR TITLE
feat/#46-comment CRUD 생성

### DIFF
--- a/community-module/src/main/java/com/pda/community_module/CommunityModuleApplication.java
+++ b/community-module/src/main/java/com/pda/community_module/CommunityModuleApplication.java
@@ -17,5 +17,4 @@ public class CommunityModuleApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(CommunityModuleApplication.class, args);
 	}
-
 }

--- a/community-module/src/main/java/com/pda/community_module/converter/CommentConverter.java
+++ b/community-module/src/main/java/com/pda/community_module/converter/CommentConverter.java
@@ -1,0 +1,45 @@
+package com.pda.community_module.converter;
+
+import com.pda.community_module.domain.Comment;
+import com.pda.community_module.web.dto.CommentResponseDTO;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class CommentConverter {
+
+    /**
+     * Comment 엔티티 -> getCommentDTO 변환
+     */
+    public static CommentResponseDTO.getCommentDTO toCommentEntity(Comment comment) {
+        CommentResponseDTO.getCommentDTO dto = new CommentResponseDTO.getCommentDTO();
+        dto.setId(comment.getId());
+        // ManyToOne 매핑이므로 Post, User 객체에서 ID를 가져옴
+        dto.setPostId(comment.getPost().getId());
+        dto.setUserId(comment.getUser().getId());
+        dto.setContent(comment.getContent());
+        return dto;
+    }
+
+    /**
+     * Comment 엔티티 리스트 -> List<getCommentDTO> 변환
+     */
+    public static List<CommentResponseDTO.getCommentDTO> toCommentListEntity(List<Comment> comments) {
+        return comments.stream()
+                .map(CommentConverter::toCommentEntity)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * createCommentDTO + Post, User 엔티티 -> Comment 엔티티 생성
+     */
+    public static Comment createCommentRequestToEntity(CommentResponseDTO.createCommentDTO requestDTO,
+                                                       com.pda.community_module.domain.Post post,
+                                                       com.pda.community_module.domain.User user) {
+        return Comment.builder()
+                .post(post)
+                .user(user)
+                .content(requestDTO.getContent())
+                .build();
+    }
+}

--- a/community-module/src/main/java/com/pda/community_module/domain/Comment.java
+++ b/community-module/src/main/java/com/pda/community_module/domain/Comment.java
@@ -9,21 +9,26 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(name = "comment")
+@Table(name = "comments")
 public class Comment extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne  // Post 엔티티와 연관관계 (외래키: post_id)
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
-    @ManyToOne
+    @ManyToOne  // User 엔티티와 연관관계 (외래키: user_id)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @Column(nullable = false, length = 255)
     private String content;
+
+    // 댓글 내용을 업데이트하는 메서드 추가
+    public void updateContent(String content) {
+        this.content = content;
+    }
 }

--- a/community-module/src/main/java/com/pda/community_module/domain/PostCount.java
+++ b/community-module/src/main/java/com/pda/community_module/domain/PostCount.java
@@ -28,4 +28,9 @@ public class PostCount extends BaseEntity {
     @Column(nullable = false)
     @Builder.Default
     private Long commentCount=0L;
+
+    // commentCount 업데이트 메서드
+    public void incrementCommentCount() {
+        this.commentCount = this.commentCount + 1;
+    }
 }

--- a/community-module/src/main/java/com/pda/community_module/repository/CommentRepository.java
+++ b/community-module/src/main/java/com/pda/community_module/repository/CommentRepository.java
@@ -1,0 +1,11 @@
+package com.pda.community_module.repository;
+
+import com.pda.community_module.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    // post 필드의 id를 기준으로 댓글 조회 (ManyToOne 매핑)
+    List<Comment> findAllByPost_Id(Long postId);
+}

--- a/community-module/src/main/java/com/pda/community_module/repository/PostCountRepository.java
+++ b/community-module/src/main/java/com/pda/community_module/repository/PostCountRepository.java
@@ -1,0 +1,11 @@
+package com.pda.community_module.repository;
+
+import com.pda.community_module.domain.Post;
+import com.pda.community_module.domain.PostCount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PostCountRepository extends JpaRepository<PostCount, Long> {
+    Optional<PostCount> findByPost(Post post);
+}

--- a/community-module/src/main/java/com/pda/community_module/service/CommentService.java
+++ b/community-module/src/main/java/com/pda/community_module/service/CommentService.java
@@ -1,0 +1,17 @@
+package com.pda.community_module.service;
+
+import com.pda.community_module.web.dto.CommentResponseDTO;
+import java.util.List;
+
+public interface CommentService {
+
+    List<CommentResponseDTO.getCommentDTO> getCommentsByPostId(Long postId);
+
+    CommentResponseDTO.getCommentDTO getCommentById(Long commentId);
+
+    CommentResponseDTO.getCommentDTO createComment(CommentResponseDTO.createCommentDTO requestDTO);
+
+    CommentResponseDTO.getCommentDTO updateComment(Long commentId, CommentResponseDTO.updateCommentDTO requestDTO);
+
+    void deleteComment(Long commentId);
+}

--- a/community-module/src/main/java/com/pda/community_module/service/CommentServiceImpl.java
+++ b/community-module/src/main/java/com/pda/community_module/service/CommentServiceImpl.java
@@ -1,0 +1,106 @@
+package com.pda.community_module.service;
+
+import com.pda.community_module.converter.CommentConverter;
+import com.pda.community_module.domain.Comment;
+import com.pda.community_module.domain.Post;
+import com.pda.community_module.domain.PostCount;
+import com.pda.community_module.domain.User;
+import com.pda.community_module.repository.CommentRepository;
+import com.pda.community_module.repository.PostRepository;
+import com.pda.community_module.repository.PostCountRepository;
+import com.pda.community_module.repository.UserRepository;
+import com.pda.community_module.web.dto.CommentResponseDTO;
+import com.pda.core_module.apiPayload.GeneralException;
+import com.pda.core_module.apiPayload.code.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.extern.slf4j.Slf4j;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class CommentServiceImpl implements CommentService {
+
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+    private final PostCountRepository postCountRepository;
+    /**
+     * 특정 게시글의 댓글 목록 조회
+     */
+    @Override
+    public List<CommentResponseDTO.getCommentDTO> getCommentsByPostId(Long postId) {
+        List<Comment> comments = commentRepository.findAllByPost_Id(postId);
+        return CommentConverter.toCommentListEntity(comments);
+    }
+
+    /**
+     * 특정 댓글 단건 조회
+     */
+    @Override
+    public CommentResponseDTO.getCommentDTO getCommentById(Long commentId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
+        return CommentConverter.toCommentEntity(comment);
+    }
+
+    /**
+     * 댓글 생성
+     */
+    @Override
+    @Transactional
+    public CommentResponseDTO.getCommentDTO createComment(CommentResponseDTO.createCommentDTO requestDTO) {
+
+        Long postId = requestDTO.getPostId();
+        log.debug("댓글 생성 요청 - postId: {}", postId);
+        // 1. 전달받은 postId, userId로 Post, User 엔티티 조회
+        Post post = postRepository.findById(requestDTO.getPostId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
+        User user = userRepository.findById(requestDTO.getUserId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
+        log.debug("조회된 Post: {}", post);
+
+        // 2. DTO + 조회된 Post, User로 Comment 엔티티 생성
+        Comment comment = CommentConverter.createCommentRequestToEntity(requestDTO, post, user);
+        // 3. DB 저장
+        commentRepository.save(comment);
+        // 4. 저장된 엔티티 -> DTO 변환 후 반환
+
+        // 3. PostCount 엔티티 조회 후 commentCount 증가
+        PostCount postCount = postCountRepository.findByPost(post)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
+        postCount.incrementCommentCount();
+        postCountRepository.save(postCount);
+
+        commentRepository.flush();
+
+        return CommentConverter.toCommentEntity(comment);
+    }
+
+    /**
+     * 댓글 수정
+     */
+    @Override
+    @Transactional
+    public CommentResponseDTO.getCommentDTO updateComment(Long commentId, CommentResponseDTO.updateCommentDTO requestDTO) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
+        // 엔티티에 setter가 필요합니다. BaseEntity 상속 시 setter가 없다면 아래 메서드를 추가하거나 엔티티에 @Setter를 추가하세요.
+        comment.updateContent(requestDTO.getContent());
+        return CommentConverter.toCommentEntity(comment);
+    }
+
+    /**
+     * 댓글 삭제
+     */
+    @Override
+    @Transactional
+    public void deleteComment(Long commentId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
+        commentRepository.delete(comment);
+    }
+}

--- a/community-module/src/main/java/com/pda/community_module/web/controller/CommentController.java
+++ b/community-module/src/main/java/com/pda/community_module/web/controller/CommentController.java
@@ -1,0 +1,51 @@
+package com.pda.community_module.web.controller;
+
+import com.pda.community_module.service.CommentService;
+import com.pda.community_module.web.dto.CommentResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/comments")
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    // 댓글 생성
+    @PostMapping
+    public ResponseEntity<CommentResponseDTO.getCommentDTO> createComment(
+            @RequestBody CommentResponseDTO.createCommentDTO requestDTO) {
+        return ResponseEntity.ok(commentService.createComment(requestDTO));
+    }
+
+    // 특정 게시글의 댓글 목록 조회
+    @GetMapping("/post/{postId}")
+    public ResponseEntity<List<CommentResponseDTO.getCommentDTO>> getCommentsByPostId(@PathVariable Long postId) {
+        return ResponseEntity.ok(commentService.getCommentsByPostId(postId));
+    }
+
+    // 특정 댓글 단건 조회
+    @GetMapping("/{commentId}")
+    public ResponseEntity<CommentResponseDTO.getCommentDTO> getCommentById(@PathVariable Long commentId) {
+        return ResponseEntity.ok(commentService.getCommentById(commentId));
+    }
+
+    // 댓글 수정
+    @PutMapping("/{commentId}")
+    public ResponseEntity<CommentResponseDTO.getCommentDTO> updateComment(
+            @PathVariable Long commentId,
+            @RequestBody CommentResponseDTO.updateCommentDTO requestDTO) {
+        return ResponseEntity.ok(commentService.updateComment(commentId, requestDTO));
+    }
+
+    // 댓글 삭제
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<Void> deleteComment(@PathVariable Long commentId) {
+        commentService.deleteComment(commentId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/community-module/src/main/java/com/pda/community_module/web/dto/CommentResponseDTO.java
+++ b/community-module/src/main/java/com/pda/community_module/web/dto/CommentResponseDTO.java
@@ -1,0 +1,42 @@
+package com.pda.community_module.web.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class CommentResponseDTO {
+
+    /**
+     * 댓글 조회 시 클라이언트에 응답할 정보
+     */
+    @Getter
+    @Setter
+    public static class getCommentDTO {
+        private Long id;
+        private Long postId;
+        private Long userId;
+        private String content;
+        // 필요시 BaseEntity의 createdAt, updatedAt도 추가 가능
+    }
+
+    /**
+     * 댓글 생성 시 요청 데이터
+     */
+    @Getter
+    @Setter
+    public static class createCommentDTO {
+        private Long postId;
+        private Long userId;
+        private String content;
+    }
+
+    /**
+     * 댓글 수정 시 요청 데이터
+     */
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class updateCommentDTO {
+        private String content;
+    }
+}


### PR DESCRIPTION
✅ 개발 및 주요 변경 사항 (Key Changes)

  1️⃣ [Comment CRUD 생성]
  댓글 기능의 생성,조회,수정,삭제를 구현하였습니다. 
  
  2️⃣ [PostCount 업데이트 관련 로직 개선]
  PATCH/POST 요청에서 post_count 테이블을 참조할 때, postId에 해당하는 레코드가 없을 경우 자동으로 생성되도록 수정.
  commentCount 증가 시, 불필요한 쿼리 실행을 방지하기 위해 incrementCommentCount() 메서드 추가.