### PR TITLE
[Refactor] 무한 스크롤 방식으로 댓글 조회 로직 변경

### DIFF
--- a/community-module/src/main/java/com/pda/community_module/repository/CommentRepository.java
+++ b/community-module/src/main/java/com/pda/community_module/repository/CommentRepository.java
@@ -1,11 +1,17 @@
 package com.pda.community_module.repository;
 
 import com.pda.community_module.domain.Comment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    // post 필드의 id를 기준으로 댓글 조회 (ManyToOne 매핑)
-    List<Comment> findAllByPost_Id(Long postId);
+    // 기존: List<Comment> findAllByPost_Id(Long postId);
+    // 커서 방식: postId와 마지막 댓글 id 기준 조회. 만약 초기 요청이면 lastCommentId를 null로 처리합니다.
+    Page<Comment> findByPost_IdAndIdLessThanOrderByIdDesc(Long postId, Long lastCommentId, Pageable pageable);
+
+    // 초기 요청용 (커서가 없는 경우 최신 데이터 조회)
+    Page<Comment> findByPost_IdOrderByIdDesc(Long postId, Pageable pageable);
 }

--- a/community-module/src/main/java/com/pda/community_module/service/CommentService.java
+++ b/community-module/src/main/java/com/pda/community_module/service/CommentService.java
@@ -2,16 +2,21 @@ package com.pda.community_module.service;
 
 import com.pda.community_module.web.dto.CommentResponseDTO;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 public interface CommentService {
 
-    List<CommentResponseDTO.getCommentDTO> getCommentsByPostId(Long postId);
+//    List<CommentResponseDTO.getCommentDTO> getCommentsByPostId(Long postId);
 
     CommentResponseDTO.getCommentDTO getCommentById(Long commentId);
 
     CommentResponseDTO.getCommentDTO createComment(CommentResponseDTO.createCommentDTO requestDTO);
 
     CommentResponseDTO.getCommentDTO updateComment(Long commentId, CommentResponseDTO.updateCommentDTO requestDTO);
+
+    Page<CommentResponseDTO.getCommentDTO> getCommentsByPostIdWithCursor(Long postId, Long lastCommentId, int limit);
 
     void deleteComment(Long commentId);
 }

--- a/community-module/src/main/java/com/pda/community_module/web/controller/CommentController.java
+++ b/community-module/src/main/java/com/pda/community_module/web/controller/CommentController.java
@@ -5,7 +5,7 @@ import com.pda.community_module.web.dto.CommentResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
+import org.springframework.data.domain.Page;
 import java.util.List;
 
 @RestController
@@ -23,10 +23,19 @@ public class CommentController {
     }
 
     // 특정 게시글의 댓글 목록 조회
-    @GetMapping("/post/{postId}")
-    public ResponseEntity<List<CommentResponseDTO.getCommentDTO>> getCommentsByPostId(@PathVariable Long postId) {
-        return ResponseEntity.ok(commentService.getCommentsByPostId(postId));
+//    @GetMapping("/post/{postId}")
+//    public ResponseEntity<List<CommentResponseDTO.getCommentDTO>> getCommentsByPostId(@PathVariable Long postId) {
+//        return ResponseEntity.ok(commentService.getCommentsByPostId(postId));
+//    }
+    @GetMapping("/post/{postId}/infinite")
+    public ResponseEntity<Page<CommentResponseDTO.getCommentDTO>> getCommentsByPostIdWithCursor(
+            @PathVariable Long postId,
+            @RequestParam(value = "lastCommentId", required = false) Long lastCommentId,
+            @RequestParam(value = "limit", defaultValue = "5") int limit) {
+        Page<CommentResponseDTO.getCommentDTO> comments = commentService.getCommentsByPostIdWithCursor(postId, lastCommentId, limit);
+        return ResponseEntity.ok(comments);
     }
+
 
     // 특정 댓글 단건 조회
     @GetMapping("/{commentId}")


### PR DESCRIPTION
## 개요
- 기존의 `getCommentsByPostId(Long postId)` 메서드를 사용한 댓글 리스트 조회 로직을 무한 스크롤 방식으로 전환했습니다.
- 더 이상 사용하지 않는 `getCommentsByPostId` 메서드와 구현 코드를 주석 처리(또는 제거)하고, 대신 `getCommentsByPostIdWithCursor` 메서드를 사용하도록 수정했습니다.

## 주요 변경 사항
1. **CommentService 인터페이스**
   - `getCommentsByPostId(Long postId)` 메서드 주석 처리(또는 삭제)
   - `getCommentsByPostIdWithCursor(Long postId, Long lastCommentId, int limit)` 메서드 추가

2. **CommentServiceImpl 구현 클래스**
   - 기존 `getCommentsByPostId(Long postId)` 구현부 주석 처리
   - `getCommentsByPostIdWithCursor` 메서드 구현:
     - `lastCommentId` 파라미터가 `null`일 때는 최신 댓글부터 조회
     - `lastCommentId`가 존재할 경우, 해당 ID보다 작은 댓글만 조회 (커서 기반)
   - 페이징(`Pageable`) 대신 `PageRequest.of(0, limit)`을 사용하여 일정 개수만큼 댓글을 가져오도록 처리

3. **CommentRepository**
   - `findAllByPost_Id(Long postId)` → 사용하지 않으면 제거하거나 그대로 두되, 주석 처리
   - `findByPost_IdOrderByIdDesc(Long postId, Pageable pageable)` 메서드 추가
   - `findByPost_IdAndIdLessThanOrderByIdDesc(Long postId, Long lastCommentId, Pageable pageable)` 메서드 추가

4. **Controller 수정 (선택 사항)**
   - 무한 스크롤을 위한 새 엔드포인트(예: `GET /comments/post/{postId}/infinite`) 추가
   - 쿼리 파라미터(`lastCommentId`, `limit`)로 다음 댓글 목록을 가져올 수 있도록 수정

## 테스트
- 새로 추가된 무한 스크롤 API(`getCommentsByPostIdWithCursor`)를 통해 댓글을 정상적으로 가져올 수 있는지 확인
- `lastCommentId`가 null일 때(초기 조회)와 특정 ID가 있을 때(추가 조회) 모두 정상 동작하는지 테스트
- 기존 API(주석 처리된 메서드)가 더 이상 필요 없다면 실제로 사용 중인 곳이 없는지 확인

## 참고 사항
- 클라이언트(프론트엔드)에서도 무한 스크롤 로직으로 변경이 필요합니다.
- 기존 API를 제거함으로써 호환성 문제가 없는지 확인이 필요합니다.
